### PR TITLE
move is_string() to the front of is_numeric()

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -90,7 +90,7 @@ class Utils
         if (is_string($value)) {
             $value = self::stripZero($value);
             $hex = implode('', unpack('H*', $value));
-        } esleif (is_numeric($value)) {
+        } elseif (is_numeric($value)) {
             // turn to hex number
             $bn = self::toBn($value);
             $hex = $bn->toHex(true);


### PR DESCRIPTION
toHex: is numbericPHP Fatal error: Uncaught Error: Call to a member function toHex() on array in \web3.php\src\Formatters\IntegerFormatter.php:36
move is_string() to the front of is_numeric(), resolve the problem of digit string recognition. such as a string "20180001"